### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/zmqservice/core.py
+++ b/zmqservice/core.py
@@ -40,7 +40,7 @@ def setGlobalContext():
     procId = getattr(zmq, 'procId', None)
     # This is the first import or ...
     # This is a new process (from a fork or similar), the old context is stale
-    if (procId == None and getattr(zmq, 'context', None) == None) or \
+    if (procId is None and getattr(zmq, 'context', None) is None) or \
        procId != os.getpid():
 
         zmq.context = zmq.Context()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:wagoodman:zmqservice?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:wagoodman:zmqservice?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
